### PR TITLE
Define face for org-modern-indent

### DIFF
--- a/org-modern-indent.el
+++ b/org-modern-indent.el
@@ -35,6 +35,11 @@
 (require 'org-indent)
 (require 'seq)
 
+;; Add face for org-modern-indent line
+(defface org-modern-indent-line '((t (:inherit (org-meta-line) :weight light)))
+  "Face for line in org-modern-indent."
+  :group 'faces)
+
 (defun org-modern-indent--face-in (faces element)
   "Determine if any of FACES are present in ELEMENT.
 FACES must be a list.  A face can be 'present' by being named
@@ -133,11 +138,11 @@ To be set as :around advice for `org-insert-structure-template'."
   (if org-modern-indent-mode
       (progn
       (setq org-modern-indent-begin
-	    (propertize "╭" 'face 'org-meta-line)
+	    (propertize "╭" 'face 'org-modern-indent-line)
 	    org-modern-indent-guide
-	    (propertize "│" 'face 'org-meta-line)
+	    (propertize "│" 'face 'org-modern-indent-line)
 	    org-modern-indent-end
-	    (propertize "╰" 'face 'org-meta-line))
+	    (propertize "╰" 'face 'org-modern-indent-line))
       (setq-local org-fontify-quote-and-verse-blocks t)
       (setf (symbol-function 'org-indent-set-line-properties)
 	    (symbol-function 'org-modern-indent-set-line-properties))


### PR DESCRIPTION
I'm not sure if you want this but I added a `defface` for an org-modern-indent face so that the user can set this is they please (I use a variable pitch face for org-meta-line so this was helpful to me...). But YMMV. Thanks for the package in any case!