### PR TITLE
Account for differing faces on real vs virtual spaces

### DIFF
--- a/org-modern-indent.el
+++ b/org-modern-indent.el
@@ -118,10 +118,9 @@ returned."
 	 (indent (current-indentation)) ; space up to #+begin_
 	 (block-indent (+ (point) indent))
 	 (search (concat "^[[:blank:]]\\{" (number-to-string indent) "\\}"))
-	 (wrap (concat (propertize
-			(make-string (if pf (+ indent (length pf) -1) indent) ?\s)
-			'face 'org-indent)
-		       org-modern-indent-guide))
+	 (wrap (concat (propertize (make-string (length pf) ?\s) 'face 'org-indent)
+                   (make-string (max (- indent 1) 0 ) ?\s)
+		           org-modern-indent-guide))
 	 orig-prefix)
     (with-silent-modifications
       (when flush		  ; formerly this block was flush left


### PR DESCRIPTION
Instead of adding the `org-indent` face to both the virtual and real spaces, treat them differently. This fixes #14 
![image](https://github.com/jdtsmith/org-modern-indent/assets/49361082/eed25bcc-8eba-472a-9590-49d27d6d3e4a)
